### PR TITLE
Mod:修复出现导航栏的水平滚动条问题

### DIFF
--- a/vue-demo/src/pages/base/mescroll-swiper-nav.vue
+++ b/vue-demo/src/pages/base/mescroll-swiper-nav.vue
@@ -399,7 +399,7 @@ export default {
   }
   .tabs-warp .tabs-content{
     width: 100%;
-    height: 50px;
+    height: 70px;/*chrome/firefox/IE滚动条默认宽度为：17px，safari滚动条默认宽度为：21px   此高度比tabs-warp高于21，普遍合适 */
     overflow-x: auto;
   }
   .tabs-warp .tabs-content .tabs{


### PR DESCRIPTION
chrome/firefox/IE滚动条默认宽度为：17px，safari滚动条默认宽度为：21px, tabs-content高度比tabs-warp大于21，能普遍修复出现导航栏水平滚动条的问题