### PR TITLE
再次文件下拉刷新 重置内容高度

### DIFF
--- a/mescroll-uni/dist/mescroll-uni.js
+++ b/mescroll-uni/dist/mescroll-uni.js
@@ -434,6 +434,7 @@ MeScroll.prototype.resetUpScroll = function(isShowLoading) {
 		this.prePageTime = page.time; // 缓存重置前的时间,加载失败可退回
 		page.num = this.startNum; // 重置为第一页
 		page.time = null; // 重置时间为空
+		this.setScrollHeight(0); // 重置内容高度为0
 		if (!this.isDownScrolling && isShowLoading !== false) { // 如果不是下拉刷新触发的resetUpScroll并且不配置列表静默更新,则显示进度;
 			if (isShowLoading == null) {
 				this.removeEmpty(); // 移除空布局

--- a/mescroll-uni/uni-demo/components/mescroll-uni/mescroll-uni.js
+++ b/mescroll-uni/uni-demo/components/mescroll-uni/mescroll-uni.js
@@ -434,6 +434,7 @@ MeScroll.prototype.resetUpScroll = function(isShowLoading) {
 		this.prePageTime = page.time; // 缓存重置前的时间,加载失败可退回
 		page.num = this.startNum; // 重置为第一页
 		page.time = null; // 重置时间为空
+		this.setScrollHeight(0); // 重置内容高度为0
 		if (!this.isDownScrolling && isShowLoading !== false) { // 如果不是下拉刷新触发的resetUpScroll并且不配置列表静默更新,则显示进度;
 			if (isShowLoading == null) {
 				this.removeEmpty(); // 移除空布局


### PR DESCRIPTION
我这边用的时候 第一次上拉加载是可以的 但当再次下拉刷新时 发现触发不了上拉加载 经过排查 是在下拉刷新时没有重置内容高度 导致在计算getScrollBottom时值一直不对