### PR TITLE
fix: 修复vue3中propObserver可能接收到null报错的问题

### DIFF
--- a/mescroll-uni/components/mescroll-uni/wxs/wxs.wxs
+++ b/mescroll-uni/components/mescroll-uni/wxs/wxs.wxs
@@ -63,6 +63,7 @@ me.clearTransform = function (ins){
  * 监听逻辑层数据的变化 (实时更新数据)
  */
 function propObserver(wxsProp) {
+	if(!wxsProp) return
 	me.optDown = wxsProp.optDown
 	me.scrollTop = wxsProp.scrollTop
 	me.bodyHeight = wxsProp.bodyHeight


### PR DESCRIPTION
<img width="555" alt="image" src="https://user-images.githubusercontent.com/26431026/156986370-9d392598-4059-46b7-9651-b404a103a246.png">
<img width="519" alt="image" src="https://user-images.githubusercontent.com/26431026/156986287-a007af54-ee5c-4ef9-98a7-5cf523861d7b.png">
