### PR TITLE
fix: Cannot read property 'nv_callType' of undefined

### DIFF
--- a/mescroll-uni/uni_modules/mescroll-uni/components/mescroll-uni/wxs/wxs.wxs
+++ b/mescroll-uni/uni_modules/mescroll-uni/components/mescroll-uni/wxs/wxs.wxs
@@ -78,6 +78,7 @@ function propObserver(wxsProp) {
  * 监听逻辑层数据的变化 (调用wxs的方法)
  */
 function callObserver(callProp, oldValue, ins) {
+	if(!callProp) return;
 	if (me.disabled()) return;
 	if(callProp.callType){
 		// 逻辑层（App Service）的style已失效,需在视图层（Webview）设置style


### PR DESCRIPTION
修复mescroll-uni在tab切换下报错：

```
[渲染层错误] TypeError: SystemError (exparserScriptError)
Cannot read property 'nv_callType' of undefined
```